### PR TITLE
Write the grounded MLN to a file

### DIFF
--- a/src/main/java/tuffy/ground/Grounding.java
+++ b/src/main/java/tuffy/ground/Grounding.java
@@ -1,9 +1,11 @@
 package tuffy.ground;
 
 
+import java.io.BufferedWriter;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 
 import tuffy.db.RDB;
@@ -16,6 +18,7 @@ import tuffy.mln.Predicate;
 import tuffy.mln.Term;
 import tuffy.util.Config;
 import tuffy.util.ExceptionMan;
+import tuffy.util.FileMan;
 import tuffy.util.StringMan;
 import tuffy.util.Timer;
 import tuffy.util.UIMan;
@@ -278,8 +281,7 @@ public class Grounding {
 		db.update(sql);
 		 */
 	}
-
-
+	
 	/**
 	 * Construct the MRF. First compute the closure of active atoms,
 	 * then active clauses.

--- a/src/main/java/tuffy/main/Infer.java
+++ b/src/main/java/tuffy/main/Infer.java
@@ -81,6 +81,10 @@ public abstract class Infer {
 
 		mln.materializeTables();
 		
+		if (Config.savePredicateNamesToDB) {
+			savePredicateTable(mln);
+		}
+		
 		KBMC kbmc = new KBMC(mln);
 		kbmc.run();
 		mln.executeAllDatalogRules();
@@ -108,6 +112,21 @@ public abstract class Infer {
 		UIMan.println(">>> Connecting to RDBMS at " + Config.db_url);
 		db = RDB.getRDBbyConfig();
 		
+	}
+	
+	protected void savePredicateTable(MarkovLogicNetwork mln) {
+		db.dropTable(Config.relPreds);
+		db.dropView(Config.relPreds);
+		String sql = "CREATE TABLE " + Config.relPreds + "(\n";
+		sql += "predid INT,\n";
+		sql += "name VARCHAR(32));";
+		db.update(sql);
+		
+		for(Predicate p : mln.getAllPredOrderByName()){			
+			sql = "INSERT INTO " + Config.relPreds + " VALUES (";
+			sql += p.getID() + ", '" + p.getRelName() + "');";
+			db.update(sql);
+		}
 	}
 	
 	/**

--- a/src/main/java/tuffy/main/PartInfer.java
+++ b/src/main/java/tuffy/main/PartInfer.java
@@ -16,8 +16,14 @@ public class PartInfer extends Infer{
 	public void run(CommandOptions opt){
 		UIMan.println(">>> Running partition-aware inference.");
 		setUp(opt);
-
+		
 		ground();
+		
+		if (Config.writeClausesFile != null) {
+			dmover.createAtomDescTable(mln.relAtoms, Config.relAtomDesc);
+			dmover.createClauseDescTable(mln.relClauses, Config.relClauseDesc);
+			dmover.dumpClauseDescToFile(Config.relClauseDesc, Config.writeClausesFile);
+		}
 		
 		InferPartitioned ip = new InferPartitioned(grounding, dmover);
 		

--- a/src/main/java/tuffy/parse/CommandOptions.java
+++ b/src/main/java/tuffy/parse/CommandOptions.java
@@ -61,6 +61,9 @@ public class CommandOptions {
     @Option(name="-pgSeed", usage="Seed for Postgres random number generator between 0.0 and 1.0 (Default = 0, which picks a random seed")
     public float pgSeed = 0.0f;
 
+    @Option(name="-writeClauses", usage="File to write the grounded MLN")
+    public String writeClausesFile = null;
+
     //@Option(name="-psec", usage="Dump MCSAT results every [psec] seconds.")
     public int mcsatDumpPeriodSec = 0;
     

--- a/src/main/java/tuffy/util/Config.java
+++ b/src/main/java/tuffy/util/Config.java
@@ -55,6 +55,13 @@ public class Config {
 	 * DB
 	 */
 	public static String relConstants = "constants";
+	public static String relPreds = "predicates";
+	public static String relAtomDesc = "atoms";
+	public static String relClauseDesc = "clauses";
+	
+	public static boolean savePredicateNamesToDB = true;
+	
+	public static String writeClausesFile = null;
 
 	public static String db_url = "jdbc:postgresql://localhost:5432/postgres";
 	public static String db_username = "tuffer";

--- a/src/main/java/tuffy/util/UIMan.java
+++ b/src/main/java/tuffy/util/UIMan.java
@@ -157,6 +157,7 @@ public class UIMan {
 		
 		Config.seed = opt.seed;
 		Config.pgSeed = opt.pgSeed;
+		Config.writeClausesFile = opt.writeClausesFile;
 		
 		Config.evidDBSchema = opt.evidDBSchema;
 		Config.dbNeedTranslate = opt.dbNeedTranslate;


### PR DESCRIPTION
@ashish33 @niranjanb 

Added a "-writeClauses <file>" option to print out the grounded MLN with original predicate names and domain constants, e.g.,

!E_barrons_rule2661_3("Var1") v Example("Var1", "Var1") v !IsaEn("Var1", "Gravity")
IsaEv("Var4", "a force") v !IsaEv("Var4", "the force")
!E_barrons_rule1530_1("Var6") v Example("Var1", "Var6") v !IsaEn("Var1", "Gravity")
